### PR TITLE
Prep for publishing v. 0.1.0

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,61 @@
+# Contributing
+
+If you find a bug or would like to request a feature, please file an
+[issue](https://github.com/Backbase/angular-devkit/issues). If you would like to contribute a
+documentation or code change, you can do so through GitHub by forking the repository and sending a
+pull request.
+
+## Local development
+
+Run `npm run generate:sources` after checking out this project to generate some required source files 
+(`npm run build` does this automatically).
+
+Use `npm run build` to build the project.  The build result is output to `/dist`.
+
+Run `npm run test` to execute tests using [jest](https://jestjs.io/).
+Coverage reports are output to `/coverage`.
+
+### Testing builders
+
+The builders have specs that run tests against some static resources in the
+[test-resources](./test-resources) directory.
+
+You can also test the builders against a real Angular project as follows:
+
+* Run `npm run build` in this root directory to build the `@bb-cli/angular-devkit` package
+* Run `cd dist && npm pack`
+* Copy the `dist/bb-cli-angular-devkit-*.tgz` package to the root directory of your real Angular project.
+* In your Angular project's root dir, run `npm i bb-cli-angular-devkit-*.tgz -D` to install the package as a dev dependency
+* Edit your Angular project's angular.json to add an `architect` target for the builder to test.
+  For example, to test the `cx-package` builder, you could add the following `package` target  
+  to the `projects.my-project-name.architect` section:
+  
+```json
+{
+  "projects": {
+    "my-project-name": {
+      "architect": {
+
+        "package": {
+          "builder": "@bb-cli/angular-devkit:cx-package",
+          "options": {
+            "items": [
+              {
+                "type": "page",
+                "name": "my-project-name-page",
+                "entryFile": "projects/my-project-name/src/index.hbs",
+                "icon": "projects/my-project-name/packaging/resources/page/icon.png",
+                "builtSources": "dist/my-project-name",
+                "modelXml": "projects/my-project-name/packaging/resources/page/model.xml"
+              }
+            ]
+          }
+        }
+
+      }
+    }
+  }
+}
+``` 
+
+You can then run the configured builder with `ng run my-project-name:package`.

--- a/README.md
+++ b/README.md
@@ -1,62 +1,30 @@
 # @bb-cli/angular-devkit
 
+![Node.js CI](https://github.com/Backbase/angular-devkit/workflows/Node.js%20CI/badge.svg)
+
 A collection of Angular dev tools for Backbase projects.
-
-Run `npm run generate:sources` after checking out this project to generate some required source files 
-(`npm run build` does this automatically).
-
-Use `npm run build` to build the project.  The build result is output to `/dist`.
-
-Run `npm run test` to execute tests using [jest](https://jestjs.io/).
-Coverage reports are output to `/coverage`.
 
 ## Builders
 
 The following [Angular Builders](https://angular.io/guide/cli-builder) are included:
 
-* [`cx-package`](./src/builders/cx-package) Used to build a CX-deployable zip-of-zips
+* [`cx-package`](https://github.com/Backbase/angular-devkit/blob/master/src/builders/cx-package/README.md):
+  Used to build a CX-deployable zip-of-zips
 
-### Testing builders
+## License
 
-The builders have specs that run tests against some static resources in the
-[test-resources](./test-resources) directory.
+```
+Copyright 2020 Backbase R&D, B.V.
 
-You can also test the builders against a real Angular project as follows:
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-* Run `npm run build` in this root directory to build the `@bb-cli/angular-devkit` package
-* Run `cd dist && npm pack`
-* Copy the `dist/bb-cli-angular-devkit-*.tgz` package to the root directory of your real Angular project.
-* In your Angular project's root dir, run `npm i bb-cli-angular-devkit-*.tgz -D` to install the package as a dev dependency
-* Edit your Angular project's angular.json to add an `architect` target for the builder to test.
-  For example, to test the `cx-package` builder, you could add the following `package` target  
-  to the `projects.my-project-name.architect` section:
-  
-```json
-{
-  "projects": {
-    "my-project-name": {
-      "architect": {
+    http://www.apache.org/licenses/LICENSE-2.0
 
-        "package": {
-          "builder": "@bb-cli/angular-devkit:cx-package",
-          "options": {
-            "items": [
-              {
-                "type": "page",
-                "name": "my-project-name-page",
-                "entryFile": "projects/my-project-name/src/index.hbs",
-                "icon": "projects/my-project-name/packaging/resources/page/icon.png",
-                "builtSources": "dist/my-project-name",
-                "modelXml": "projects/my-project-name/packaging/resources/page/model.xml"
-              }
-            ]
-          }
-        }
-
-      }
-    }
-  }
-}
-``` 
-
-You can then run the configured builder with `ng run my-project-name:package`.
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+```

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "generate:sources": "json2ts -i src/builders/cx-package/schema.json -o src/builders/cx-package/schema.d.ts",
     "prebuild": "rm -rf dist && npm run generate:sources",
     "build": "tsc -p tsconfig.lib.json",
+    "postbuild": "cp README.md LICENSE dist",
     "test": "jest",
     "lint": "eslint src",
     "format": "npx prettier --write src"

--- a/src/builders/cx-package/README.md
+++ b/src/builders/cx-package/README.md
@@ -2,9 +2,7 @@
 
 Generates a CX zip-of-zips package.
 
-Run `npm run generate:sources` in the repo root dir to generate the `schema.d.ts` file in this dir.
-
-See the [root project README](../../../README.md) for build and test instructions.
+This builder currently supports packaging one type of artifact: A CX6 Page.
 
 ## Builder options
 
@@ -12,3 +10,9 @@ See the [schema.json](./schema.json) file for the configuration options availabl
 
 Note that this builder does not invoke `ng build` - this must be done before using
 this builder to create a CX package.
+
+## Local development
+
+Run `npm run generate:sources` in the repo root dir to generate the `schema.d.ts` file in this dir.
+
+See the [root project README](../../../README.md) for build and test instructions.


### PR DESCRIPTION
* Move developer guide from README.md to CONTRIBUTING.md
* Add license and npmjs-friendly summary to README.md
* Ensure README.md and LICENSE file are included in the build output